### PR TITLE
Safely retrieve error message from ElasticSearch JSON response

### DIFF
--- a/hayes/transport.py
+++ b/hayes/transport.py
@@ -43,12 +43,13 @@ class ESSession(requests.Session):
         kwargs.update(method=method, url=url, data=data)
 
         resp = super(ESSession, self).request(**kwargs)
+        error_message = resp.json().get("error", "")
         if resp.status_code == 404:
-            raise NotFoundError(resp.json()["error"], response=resp)
+            raise NotFoundError(error_message, response=resp)
         elif resp.status_code == 400:
-            raise BadRequestError(resp.json()["error"], response=resp)
+            raise BadRequestError(error_message, response=resp)
         elif resp.status_code == 403:
-            raise ForbiddenError(resp.json()["error"], response=resp)
+            raise ForbiddenError(error_message, response=resp)
         resp.raise_for_status()
         return resp
 


### PR DESCRIPTION
> Safely retrieve error message from ElasticSearch JSON response
>
> Avoid raising a KeyError if response does not contain "error" entry
> Use dict.get() method with the empty string as default argument

This PR fixes an issue where the status code of a response was an error code but the response JSON did not contain an `error` key-value pair. This meant Python's `KeyError` was raised instead of one of the internally handled Hayes exception classes.